### PR TITLE
Corrected wrong call to Mailer sendmessage

### DIFF
--- a/lib/Newsletter/DBObject/User.php
+++ b/lib/Newsletter/DBObject/User.php
@@ -76,7 +76,7 @@ class Newsletter_DBObject_User extends DBObject
                                                                         'fromaddress'=> $send_from_address,
                                                                         'subject'    => __('Newsletter Subscription Cancelled', $dom),
                                                                         'body'       => $message,
-                                                                        'html'       => 1));
+                                                                        'html'       => true));
             }
         }
 
@@ -234,7 +234,7 @@ class Newsletter_DBObject_User extends DBObject
                                                                 'fromaddress'=> $send_from_address,
                                                                 'subject'    => __('Newsletter Subscription Received', $dom),
                                                                 'body'       => $user_message,
-                                                                'html'       => 1));
+                                                                'html'       => true));
 
             if (ModUtil::getVar('Newsletter', 'notify_admin', 0)) {
                 $admin_message = $view->fetch ('email/admin_notify.tpl');
@@ -242,7 +242,7 @@ class Newsletter_DBObject_User extends DBObject
                                                                     'fromaddress'=> $send_from_address,
                                                                     'subject'    => __('Newsletter Subscription', $dom),
                                                                     'body'       => $admin_message,
-                                                                    'html'       => 1));
+                                                                    'html'       => true));
             }
         }
 


### PR DESCRIPTION
Zikula Mailer sendmessage requires boolean type for parameter 'html', as seen from this code fragment from system/Mailer/lib/Mailer/Api/User.php:

```
if (isset($args['html']) && is_bool($args['html'])) {
    $mail->IsHTML($args['html']); // set email format to HTML
} else {
    $mail->IsHTML($this->getVar('html')); // set email format to the default
}
```

Proposed changes in this PR coorects the wrong call.

Also, in case of plane text message format, the message body is treated as required.
