### PR TITLE
Toggle editor usage in Newsletter edit

### DIFF
--- a/lib/Newsletter/Controller/Admin.php
+++ b/lib/Newsletter/Controller/Admin.php
@@ -434,6 +434,7 @@ class Newsletter_Controller_Admin extends Zikula_AbstractController
         $this->throwForbiddenUnless(SecurityUtil::checkPermission('Newsletter::', '::', ACCESS_ADMIN));
 
         $id  = (int)FormUtil::getPassedValue('id', $args['id'] ? $args['id'] : 0);
+        $useeditor = (int)FormUtil::getPassedValue('useeditor', $args['useeditor'] ? $args['useeditor'] : 0);
 
         $url = ModUtil::url('Newsletter', 'admin', 'newsletters');
 
@@ -442,6 +443,7 @@ class Newsletter_Controller_Admin extends Zikula_AbstractController
             $data = $objArchive->get($id);
             if ($data) {
                 $this->view->assign('newsletter', $data);
+                $this->view->assign('useeditor', $useeditor);
 
                 return $this->view->fetch("admin/edit_newsletter.tpl");
             }

--- a/templates/admin/edit_newsletter.tpl
+++ b/templates/admin/edit_newsletter.tpl
@@ -17,7 +17,9 @@
 
         <div class="z-formrow">
             <label for="content_html">{gt text="HTML"}</label>
-            <textarea class="noeditor" id="content_html" name="html" cols="65" rows="20" >{$newsletter.html|safetext}</textarea>
+            {if $useeditor}{assign var='toggleeditor' value=0}{else}{assign var='toggleeditor' value=1}{/if}
+            <a href="{modurl modname='Newsletter' type='admin' func='editnewsletter' id=$newsletter.id useeditor=$toggleeditor}">{gt text='Toggle editor'} ({gt text='page reload!'})</a>
+            <textarea class="fullpageeditor" id="content_html" name="html" cols="65" rows="20" >{$newsletter.html|safetext}</textarea>
         </div>
         <br />
         <div class="z-formrow">
@@ -25,7 +27,7 @@
             <textarea class="noeditor" id="content_text" name="text" cols="65" rows="20" >{$newsletter.text|safetext}</textarea>
         </div>
 
-        {notifydisplayhooks eventname='newsletter.ui_hooks.items.form_edit'}
+        {if $useeditor}{notifydisplayhooks eventname='newsletter.ui_hooks.items.form_edit'}{/if}
         <br />
         <div class="z-buttons z-formbuttons">
             {button src='button_ok.png' set='icons/small' id='submit' name='submit' value='submit' __alt='Update' __title='Update' __text='Update'}


### PR DESCRIPTION
Toggle online HTML editor - works with Scribite 5.

Full page edit mode is not available for now - it is dependent on editor itself and Scribite implementation.
