### PR TITLE
Refactoring Dizkus plugin to work with current dev status

### DIFF
--- a/lib/Newsletter/DBObject/PluginDownloadsArray.php
+++ b/lib/Newsletter/DBObject/PluginDownloadsArray.php
@@ -40,7 +40,7 @@ class Newsletter_DBObject_PluginDownloadsArray extends Newsletter_DBObject_Plugi
         } catch (Exception $e) {
             return LogUtil::registerError(__('Error in plugin').' Downloads: ' . $e->getMessage());
         }
-        $items = $stmt->fetchAll(Doctrine::FETCH_ASSOC);
+        $items = $stmt->fetchAll(Doctrine_Core::FETCH_ASSOC);
 
         return $items;
     }

--- a/lib/Newsletter/DBObject/PluginWeblinksArray.php
+++ b/lib/Newsletter/DBObject/PluginWeblinksArray.php
@@ -40,7 +40,7 @@ class Newsletter_DBObject_PluginWeblinksArray extends Newsletter_DBObject_Plugin
         } catch (Exception $e) {
             return LogUtil::registerError(__('Error in plugin').' Weblinks: ' . $e->getMessage());
         }
-        $items = $stmt->fetchAll(Doctrine::FETCH_ASSOC);
+        $items = $stmt->fetchAll(Doctrine_Core::FETCH_ASSOC);
 
         return $items;
     }

--- a/templates/output/html.tpl
+++ b/templates/output/html.tpl
@@ -353,7 +353,7 @@ ul li {
                       {foreach from=$objectArray.Dizkus item="item" name="loop"}
                         <div class="content" style="padding:15px;max-width:600px;margin:0 auto;display:block;background-color:#ECF8FF;-webkit-border-radius: 0px 0px 4px 4px;border-radius: 0px 0px 4px 4px;">
 						<h4 style="font-weight:500; font-size: 23px;color:#fff;"><a href="{modurl modname="Dizkus" type="user" func="viewtopic" topic=$item.topic_id newlang=$nllang fqurl=true}">{$item.topic_title}</a></h4>
-                         
+                        <p>{$item.username}<br />{$item.post_text|nlTreatContent:'Dizkus'}</p>
 						</div>
 					  {/foreach}                    
                     {/if}

--- a/templates/output/html_1.tpl
+++ b/templates/output/html_1.tpl
@@ -109,6 +109,7 @@
                       <img style="margin: 0; padding: 0 0 10px 0;" src="{$site_url}modules/Newsletter/images/newsletter_images/hr.gif" alt="Newsletter" width="560" height="3" />
                       {foreach from=$objectArray.Dizkus item="item" name="loop"}
                         <h3 style="font-size: 14px; font-weight: bold; color: #813939; margin: 0; padding: 0;"><a style="color: #813939; text-decoration: none;" href="{modurl modname="Dizkus" type="user" func="viewtopic" topic=$item.topic_id newlang=$nllang fqurl=true}">{$item.topic_title}</a></h3>
+                        <div style="font-size: 13px; color: #333333; margin: 0 0 14px 0; padding: 0;">{$item.username}<br />{$item.post_text|nlTreatContent:'Dizkus'}</div>
                          {if (!$smarty.foreach.loop.last)}<img style="margin: 0; padding: 0 0 10px 0;" src="{$site_url}modules/Newsletter/images/newsletter_images/hr-small.gif" alt="Newsletter" width="560" height="2" />{/if}
                       {/foreach}
                       <br />

--- a/templates/output/html_2.tpl
+++ b/templates/output/html_2.tpl
@@ -156,6 +156,7 @@
 																		<div style="color: #999; font-size:14px; margin-top: 4px; margin-bottom:8px; color: #999; border-bottom: 1px solid #eee; overflow: hidden">
 																		{foreach from=$objectArray.Dizkus item="item" name="loop"}
 																		<h3><a href="{modurl modname="Dizkus" type="user" func="viewtopic" topic=$item.topic_id newlang=$nllang fqurl=true}">{$item.topic_title}</a></h3>
+																		<p>{$item.username}<br />{$item.post_text|nlTreatContent:'Dizkus'}</p>
 																		{if (!$smarty.foreach.loop.last)}<img class="hr" src="{$site_url}modules/Newsletter/images/newsletter_images/hr-small.gif" alt="Newsletter" width="560" height="2" />{/if}
 																		{/foreach}
 																		</div>

--- a/templates/output/text.tpl
+++ b/templates/output/text.tpl
@@ -64,7 +64,10 @@
 {gt text="Latest Forum Posts"}
 ===========================
 {foreach from=$objectArray.Dizkus item="item"}
+
 {$item.topic_title}
+{$item.username}
+{$item.post_text|nlTreatContent:'Dizkus':false}
 {/foreach}
 {/if}
 {if (isset($objectArray.Clip) && $objectArray.Clip)}


### PR DESCRIPTION
Dizkus now works with last Dizkus dev status.
Also added poster name and last post text.
Related to #89.

Also small corrections to Weblinks and Dounload plugins - to be able to work in Zikula 1.3.6 dev environment.
