### PR TITLE
Special newsletter user permision implemented for Dizkus

### DIFF
--- a/lib/Newsletter/DBObject/PluginDizkusArray.php
+++ b/lib/Newsletter/DBObject/PluginDizkusArray.php
@@ -30,6 +30,10 @@ class Newsletter_DBObject_PluginDizkusArray extends Newsletter_DBObject_PluginBa
         ModUtil::dbInfoLoad ('Dizkus');
         $nItems = ModUtil::getVar ('Newsletter', 'plugin_Dizkus_nItems', 1);
 
+        // this can be setting in future
+        // $userNewsletter = 0; this can be default in future, if Zikula core start to accept such parameter in SecurityUtil::checkPermission
+        $userNewsletter = 1; // by default userid=1 is for guest, but it is member of Users group in practice. Better then to chow all forums topics
+
         $connection = Doctrine_Manager::getInstance()->getCurrentConnection();
         $sql = "SELECT forum_id FROM dizkus_forums WHERE 1";
         $stmt = $connection->prepare($sql);
@@ -41,7 +45,7 @@ class Newsletter_DBObject_PluginDizkusArray extends Newsletter_DBObject_PluginBa
         $userforums = $stmt->fetchAll(Doctrine_Core::FETCH_ASSOC);
         $allowedforums = array();
         foreach (array_keys($userforums) as $k) {
-            if (SecurityUtil::checkPermission('Dizkus::', ":".$userforums[$k]['forum_id'].":", ACCESS_READ)) {
+            if (SecurityUtil::checkPermission('Dizkus::', ":".$userforums[$k]['forum_id'].":", ACCESS_READ, $userNewsletter)) {
                 $allowedforums[] = $userforums[$k]['forum_id'];
             }
         }


### PR DESCRIPTION
This is an example how can we implement special permissions (related to issue #8).

In same time it fixes the problem for forums - they are very sensitive in this issue, for example it is possible to have forum for administrators, and now topics in such a forum will not be exposed in the generated newsletter.

It is possible all (or most) of plugins to refactor in similar way (in future, not right now).
